### PR TITLE
Fixes duplicate "LevelStart" log bug

### DIFF
--- a/Assets/_CompletedAssets/Scripts/Managers/LevelTransitionManager.cs
+++ b/Assets/_CompletedAssets/Scripts/Managers/LevelTransitionManager.cs
@@ -105,6 +105,7 @@ namespace CompleteProject
 
         void PlayerIsReadyToStart()
         {
+            levelStartCanvas.GetComponentInChildren<Button>().enabled = false;
             StartCoroutine(FadeEffect.FadeCanvas(levelStartCanvas.gameObject, 1.0f, 0.0f, 0.125f, BeginPlay));
         }
 


### PR DESCRIPTION
If the player is spamming the "A" button on the instructions screen, they can trigger multiple "LevelStart" log entries to be written. This patch simply disables the button on the first press, preventing subsequent presses and the superfluous "LevelStart" log entries